### PR TITLE
Sokoban: make vertical levels horizontal to better fit the screen

### DIFF
--- a/sokoban/application.fam
+++ b/sokoban/application.fam
@@ -9,7 +9,7 @@ App(
     order=50,
     fap_description="Sokoban on Flipper Zero. Solve your path to victory!",
     fap_category="Games",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_author="Racso",
     fap_weburl="https://games.by.rac.so/flipper-zero",
     fap_icon="sokoban.png",

--- a/sokoban/scripts/scene_game.c
+++ b/sokoban/scripts/scene_game.c
@@ -21,7 +21,6 @@
 #define MAX_READ_BUFFER_SIZE 256
 #define MAX_FILENAME_LEN 256
 #define MAX_BOARD_SIZE 50
-#define CELL_SIZE 9
 #define MAX_UNDO_STATES 10
 
 typedef enum
@@ -161,12 +160,18 @@ static int level_reader_parse_row(const char* line, CellType* row)
 
 static int level_reader_calculate_cell_size(int width, int height)
 {
+    #define MAX_WIDTH (128 + (cellSize - 1) * 2)
+    #define MAX_HEIGHT (64 + (cellSize - 1) * 2)
+
     int cellSize = 9;
-    if (width * cellSize > 128 || height * cellSize > 64)
+    if (width * cellSize > MAX_WIDTH || height * cellSize > MAX_HEIGHT)
         cellSize = 7;
-    if (width * cellSize > 128 || height * cellSize > 64)
+    if (width * cellSize > MAX_WIDTH || height * cellSize > MAX_HEIGHT)
         cellSize = 5;
     return cellSize;
+
+    #undef MAX_WIDTH
+    #undef MAX_HEIGHT
 }
 
 void level_reader_load_level(Level* ret_level, FileLinesReader* reader, int levelIndex)
@@ -303,41 +308,38 @@ const Icon* findIcon(CellType cellType, int size)
 void draw_game(Canvas* const canvas, GameContext* game)
 {
     GameState* state = stack_peek(game->states);
+    Level *level = game->level;
 
-    int cellSize = game->level->cell_size;
-    int canvasSizeX = 128 / cellSize;
-    int canvasSizeY = 64 / cellSize;
-    int centerX = canvasSizeX / 2;
-    int centerY = canvasSizeY / 2;
-    int fromX, toX, fromY, toY;
+    int cellSize = level->cell_size;
+    int levelWidth = level->level_width * cellSize;
+    int levelHeight = level->level_height * cellSize;
 
-    fromX = MAX(0, state->playerX - centerX);
-    fromY = MAX(0, state->playerY - centerY);
-    toX = fromX + canvasSizeX;
-    toY = fromY + canvasSizeY;
+    int playerX = state->playerX * cellSize;
+    int playerY = state->playerY * cellSize;
 
-    if (toX > game->level->level_width)
+    int screenWidth = 128;
+    int screenHeight = 64;
+
+    int minScrollingWidth = screenWidth + (cellSize - 1) * 2;
+    int minScrollingHeight = screenHeight + (cellSize - 1) * 2;
+
+    int cameraX = levelWidth / 2;
+    if (levelWidth > minScrollingWidth)
+        cameraX = MAX(screenWidth / 2, MIN(playerX, levelWidth - screenWidth / 2));
+
+    int cameraY = levelHeight / 2;
+    if (levelHeight > minScrollingHeight)
+        cameraY = MAX(screenHeight / 2, MIN(playerY, levelHeight - screenHeight / 2));
+
+    for (int row = 0; row < level->level_height; row++)
     {
-        fromX -= toX - game->level->level_width;
-        toX = game->level->level_width;
-    }
-    if (toY > game->level->level_height)
-    {
-        fromY -= toY - game->level->level_height;
-        toY = game->level->level_height;
-    }
-
-    fromX = MAX(0, fromX);
-    fromY = MAX(0, fromY);
-
-    for (int y = fromY; y < toY; y++)
-    {
-        for (int x = fromX; x < toX; x++)
+        for (int column = 0; column < level->level_width; column++)
         {
-            int cellX = (x - fromX) * cellSize, cellY = (y - fromY) * cellSize;
-            const Icon* icon = findIcon(state->board[y][x], cellSize);
+            int x = column * cellSize - cameraX + screenWidth / 2;
+            int y = row * cellSize - cameraY + screenHeight / 2;
+            const Icon* icon = findIcon(state->board[row][column], cellSize);
             if (icon)
-                canvas_draw_icon(canvas, cellX, cellY, icon);
+                canvas_draw_icon(canvas, x, y, icon);
         }
     }
 }

--- a/sokoban/scripts/scene_game.c
+++ b/sokoban/scripts/scene_game.c
@@ -38,6 +38,7 @@ typedef enum
 typedef struct Level
 {
     int level_width, level_height;
+    int cell_size;
     CellType board[MAX_BOARD_SIZE][MAX_BOARD_SIZE];
 } Level;
 
@@ -119,111 +120,101 @@ void victory_popup_handle_input(InputKey key, InputType type, AppContext* app)
     }
 }
 
-bool level_reader_parse_symbol(char ch, CellType* cellType)
+static int level_reader_parse_row(const char* line, CellType* row)
 {
-    switch (ch)
+    const char *ch = line;
+    int i = 0;
+    while (true)
     {
-    case '#':
-        *cellType = CellType_Wall;
-        return true;
-    case '*':
-        *cellType = CellType_BoxOnTarget;
-        return true;
-    case '.':
-        *cellType = CellType_Target;
-        return true;
-    case '@':
-        *cellType = CellType_Player;
-        return true;
-    case '+':
-        *cellType = CellType_PlayerOnTarget;
-        return true;
-    case '$':
-        *cellType = CellType_Box;
-        return true;
-    case ' ':
-        *cellType = CellType_Empty;
-        return true;
-    default:
-        return false;
+        if (i >= MAX_BOARD_SIZE)
+            return -1;
+        switch (*(ch++))
+        {
+        case '\0':
+            return i;
+        case '#':
+            row[i++] = CellType_Wall;
+            break;
+        case '*':
+            row[i++] = CellType_BoxOnTarget;
+            break;
+        case '.':
+            row[i++] = CellType_Target;
+            break;
+        case '@':
+            row[i++] = CellType_Player;
+            break;
+        case '+':
+            row[i++] = CellType_PlayerOnTarget;
+            break;
+        case '$':
+            row[i++] = CellType_Box;
+            break;
+        case ' ':
+            row[i++] = CellType_Empty;
+            break;
+        default:
+            return -2;
+        }
     }
 }
 
-bool level_reader_is_level_line(const char* line)
+static int level_reader_calculate_cell_size(int width, int height)
 {
-    for (int i = 0; line[i] != '\0'; i++)
-    {
-        CellType cellType;
-        if (!level_reader_parse_symbol(line[i], &cellType))
-            return false;
-    }
-
-    return true;
-}
-
-bool level_reader_is_level_start_mark(const char* line)
-{
-    bool hasNumber = false;
-    for (int i = 0; line[i] != '\0'; i++)
-    {
-        if (line[i] >= '0' && line[i] <= '9')
-            hasNumber = true;
-        else if (line[i] != ' ')
-            return false;
-    }
-
-    return hasNumber;
+    int cellSize = 9;
+    if (width * cellSize > 128 || height * cellSize > 64)
+        cellSize = 7;
+    if (width * cellSize > 128 || height * cellSize > 64)
+        cellSize = 5;
+    return cellSize;
 }
 
 void level_reader_load_level(Level* ret_level, FileLinesReader* reader, int levelIndex)
 {
-    ret_level->level_width = 0;
-    ret_level->level_height = 0;
-    for (int i = 0; i < MAX_BOARD_SIZE; i++)
-        for (int j = 0; j < MAX_BOARD_SIZE; j++)
-            ret_level->board[i][j] = CellType_Empty;
+    CellType board[MAX_BOARD_SIZE][MAX_BOARD_SIZE] = {CellType_Empty};
+    int columnCount = 0, rowCount = 0;
+    char line[MAX_READ_BUFFER_SIZE];
 
-    for (int currentLevelFound = 0; currentLevelFound <= levelIndex; currentLevelFound++)
+    char levelStartMark[16];
+    snprintf(levelStartMark, sizeof(levelStartMark), "%d", levelIndex + 1);
+
+    bool levelFound = false;
+    while (!levelFound && file_lines_reader_readln(reader, line, sizeof(line)))
+        if (strncmp(levelStartMark, line, sizeof(levelStartMark)) == 0)
+            levelFound = true;
+
+    furi_check(levelFound, "level not found");
+
+    while (file_lines_reader_readln(reader, line, sizeof(line)))
     {
-        char line[MAX_READ_BUFFER_SIZE];
-
-        while (!level_reader_is_level_start_mark(line))
-        {
-            file_lines_reader_readln(reader, line, MAX_READ_BUFFER_SIZE);
-            if (file_lines_reader_is_eof(reader))
-                return;
-        };
-
-        for (int i = 0; i < MAX_BOARD_SIZE; i++)
-        {
-            if (file_lines_reader_is_eof(reader))
-                return;
-
-            file_lines_reader_readln(reader, line, MAX_READ_BUFFER_SIZE);
-            if (!level_reader_is_level_line(line))
-                break;
-
-            if (currentLevelFound < levelIndex)
-                continue;
-
-            ret_level->level_height += 1;
-
-            int lineLen = strlen(line);
-            if (lineLen > ret_level->level_width)
-                ret_level->level_width = lineLen;
-
-            for (int j = 0; j < lineLen; j++)
-            {
-                CellType cellType;
-                if (level_reader_parse_symbol(line[j], &cellType))
-                    ret_level->board[i][j] = cellType;
-            }
-        }
-
-        if (currentLevelFound == levelIndex)
-            return;
+        int rowSize = level_reader_parse_row(line, board[rowCount]);
+        if (rowSize < 0)
+            break;
+        if (rowSize > columnCount)
+            columnCount = rowSize;
+        rowCount += 1;
+        if (rowCount >= MAX_BOARD_SIZE)
+            break;
     }
-    return;
+
+    int naturalCellSize = level_reader_calculate_cell_size(columnCount, rowCount);
+    int rotatedCellSize = level_reader_calculate_cell_size(rowCount, columnCount);
+    if (naturalCellSize >= rotatedCellSize)
+    {
+        ret_level->cell_size = naturalCellSize;
+        ret_level->level_width = columnCount;
+        ret_level->level_height = rowCount;
+        memcpy(ret_level->board, board, sizeof(board));
+    }
+    else
+    {
+        ret_level->cell_size = rotatedCellSize;
+        ret_level->level_width = rowCount;
+        ret_level->level_height = columnCount;
+        for (int row = 0; row < rowCount; row++)
+            for (int column = 0; column < columnCount; column++)
+                ret_level->board[column][row] = board[row][column];
+    }
 }
 
 const Icon* findIcon(CellType cellType, int size)
@@ -309,10 +300,11 @@ const Icon* findIcon(CellType cellType, int size)
     return NULL;
 }
 
-void draw_game(Canvas* const canvas, GameContext* game, int cellSize)
+void draw_game(Canvas* const canvas, GameContext* game)
 {
     GameState* state = stack_peek(game->states);
 
+    int cellSize = game->level->cell_size;
     int canvasSizeX = 128 / cellSize;
     int canvasSizeY = 64 / cellSize;
     int centerX = canvasSizeX / 2;
@@ -361,13 +353,7 @@ void game_render_callback(Canvas* const canvas, void* context)
     if (state == NULL || level == NULL)
         return;
 
-    int cellSize = 9;
-    if (level->level_width * cellSize > 128 || level->level_height * cellSize > 64)
-        cellSize = 7;
-    if (level->level_width * cellSize > 128 || level->level_height * cellSize > 64)
-        cellSize = 5;
-
-    draw_game(canvas, &game, cellSize);
+    draw_game(canvas, &game);
 
     if (game.isCompleted)
         victory_popup_render_callback(canvas, app);


### PR DESCRIPTION
Some levels (in the "Microban" back, at least) are way too small, but only take up less than half of the screen:

<details>
<summary>Screenshot: Microban, level 8</summary>

![Microban level 8](https://github.com/user-attachments/assets/8e487f4a-bff4-4f15-96f9-b8e1757c7258)
</details>

This PR makes vertical levels into horizontal ones to better fit the screen.

The levels were processed by this Node.js script: https://gist.github.com/iliazeus/9fd14a338c21d5f5441a8351c955fcfe

Here's a screenshot of a rotated (well, "transposed" would be a better word) level, for comparison:

<details>
<summary>Screenshot: Microban, level 8, horizontal</summary>

![Screenshot: Microban, level 8, horizontal](https://github.com/user-attachments/assets/2312a6c6-4540-4930-917e-fd2219e8bd52)
</details>

(reopened from #7 because I wanted to rename the source branch)