### PR TITLE
Sokoban: draw centered levels without scrolling and with bigger tiles if possible

### DIFF
--- a/sokoban/scripts/scene_game.c
+++ b/sokoban/scripts/scene_game.c
@@ -343,11 +343,23 @@ void game_render_callback(Canvas* const canvas, void* context)
     if (state == NULL || level == NULL)
         return;
 
+    #define SCREEN_WIDTH (128 + (cellSize - 1) * 2)
+    #define SCREEN_HEIGHT (64 + (cellSize - 1) * 2)
+
+    #define LEVEL_WIDTH (level->level_width * cellSize)
+    #define LEVEL_HEIGHT (level->level_height * cellSize)
+
     int cellSize = 9;
-    if (level->level_width * cellSize > 128 || level->level_height * cellSize > 64)
+    if (LEVEL_WIDTH > SCREEN_WIDTH || LEVEL_HEIGHT > SCREEN_HEIGHT)
         cellSize = 7;
-    if (level->level_width * cellSize > 128 || level->level_height * cellSize > 64)
+    if (LEVEL_WIDTH > SCREEN_WIDTH || LEVEL_HEIGHT > SCREEN_HEIGHT)
         cellSize = 5;
+
+    #undef SCREEN_WIDTH
+    #undef SCREEN_HEIGHT
+
+    #undef LEVEL_WIDTH
+    #undef LEVEL_HEIGHT
 
     draw_game(canvas, &game, cellSize);
 

--- a/sokoban/scripts/scene_game.c
+++ b/sokoban/scripts/scene_game.c
@@ -313,39 +313,21 @@ void draw_game(Canvas* const canvas, GameContext* game, int cellSize)
 {
     GameState* state = stack_peek(game->states);
 
-    int canvasSizeX = 128 / cellSize;
-    int canvasSizeY = 64 / cellSize;
-    int centerX = canvasSizeX / 2;
-    int centerY = canvasSizeY / 2;
-    int fromX, toX, fromY, toY;
+    int w = game->level->level_width * cellSize;
+    int h = game->level->level_height * cellSize;
 
-    fromX = MAX(0, state->playerX - centerX);
-    fromY = MAX(0, state->playerY - centerY);
-    toX = fromX + canvasSizeX;
-    toY = fromY + canvasSizeY;
+    int dx = 128 / 2;
+    int dy = 64 / 2;
 
-    if (toX > game->level->level_width)
+    for (int row = 0; row < game->level->level_height; row++)
     {
-        fromX -= toX - game->level->level_width;
-        toX = game->level->level_width;
-    }
-    if (toY > game->level->level_height)
-    {
-        fromY -= toY - game->level->level_height;
-        toY = game->level->level_height;
-    }
-
-    fromX = MAX(0, fromX);
-    fromY = MAX(0, fromY);
-
-    for (int y = fromY; y < toY; y++)
-    {
-        for (int x = fromX; x < toX; x++)
+        for (int col = 0; col < game->level->level_width; col++)
         {
-            int cellX = (x - fromX) * cellSize, cellY = (y - fromY) * cellSize;
-            const Icon* icon = findIcon(state->board[y][x], cellSize);
+            int x = dx + col * cellSize - w / 2;
+            int y = dy + row * cellSize - h / 2;
+            const Icon* icon = findIcon(state->board[row][col], cellSize);
             if (icon)
-                canvas_draw_icon(canvas, cellX, cellY, icon);
+                canvas_draw_icon(canvas, x, y, icon);
         }
     }
 }


### PR DESCRIPTION
Draw levels centered; do not scroll them; allow edge tiles to be off screen (but leave at least one pixel of them visible).

There's not much info lost, since edge tiles are always walls anyway. But it allows us to have bigger tiles:

<details><summary>Microban lvl 60 - before</summary>

![Screenshot-20240722-175355](https://github.com/user-attachments/assets/0c56f371-949e-4db2-a059-99a15e292ced)
</details>

<details><summary>Microban lvl 60 - after</summary>

![Screenshot-20240722-181833](https://github.com/user-attachments/assets/8afbea53-bf1d-4976-91a2-4acdfb0d4c4a)
</details>

Disabling scrolling won't allow for very huge levels, but I think huge levels are bad game design for a Flipper game anyway :)